### PR TITLE
Patch itc503 proto

### DIFF
--- a/itc503Sup/itc503.proto
+++ b/itc503Sup/itc503.proto
@@ -33,7 +33,7 @@ get_gflow{out"R7"; in"R%f"}
 get_p{out"R8"; in"R%f"}
 get_i{out"R9"; in"R%f"}
 get_d{out"R10"; in"R%f"}
-get_sta{out"X"; in "X0%{A0|A1|A2|A3}%(\$1CTRL.VAL){C0|C1|C2|C3}%(\$1SWEEPING.VAL)#{S00=0|S0=0|S1=1|S01=1|=0}%(\$1CTRLCHANNEL.VAL){H1|H2|H3|}%(\$1AUTOPID.VAL){L0|L1}"}
+get_sta{out"X"; in "X0%{A0|A1|A2|A3}%(\$1CTRL.VAL){C0|C1|C2|C3}%(\$1SWEEPING.VAL)#{S00=0|S01=1|S0=0|S1=1|=0}%(\$1CTRLCHANNEL.VAL){H1|H2|H3|}%(\$1AUTOPID.VAL){L0|L1}"}
 
 
 #Control commands

--- a/itc503Sup/itc503.proto
+++ b/itc503Sup/itc503.proto
@@ -33,7 +33,7 @@ get_gflow{out"R7"; in"R%f"}
 get_p{out"R8"; in"R%f"}
 get_i{out"R9"; in"R%f"}
 get_d{out"R10"; in"R%f"}
-get_sta{out"X"; in "X0%{A0|A1|A2|A3}%(\$1CTRL.VAL){C0|C1|C2|C3}%(\$1SWEEPING.VAL)#{S0=0|S00=0|S1=1|S01=1|=0}%(\$1CTRLCHANNEL.VAL){H1|H2|H3|}%(\$1AUTOPID.VAL){L0|L1}"}
+get_sta{out"X"; in "X0%{A0|A1|A2|A3}%(\$1CTRL.VAL){C0|C1|C2|C3}%(\$1SWEEPING.VAL)#{S00=0|S0=0|S1=1|S01=1|=0}%(\$1CTRLCHANNEL.VAL){H1|H2|H3|}%(\$1AUTOPID.VAL){L0|L1}"}
 
 
 #Control commands


### PR DESCRIPTION
EMU's ITC503 reports sweeping with a leading 0 i.e. `...S00...` instead of `...S0...`. However `S0` was first in the enum matcher so this was matched, and then the second zero caused a protocol mismatch error.

IOC test for this case added in:
- https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/289
- https://github.com/ISISComputingGroup/EPICS-DeviceEmulator/pull/64